### PR TITLE
Use hostPort in Kubernetes deployment file instead of Service

### DIFF
--- a/snmpd-monitor.yaml
+++ b/snmpd-monitor.yaml
@@ -1,25 +1,4 @@
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  creationTimestamp: null
-  labels:
-    app: snmpd-monitor
-  name: snmpd-monitor
-spec:
-  ports:
-  - name: snmp-monitoring-port
-    # If required, modify here the port opened on the host side. The range of valid ports is 9000-32000.
-    nodePort: 30161
-    port: 161
-    protocol: UDP
-    targetPort: 161
-  selector:
-    app: snmpd-monitor
-  type: NodePort
-status:
-  loadBalancer: {}
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -48,6 +27,8 @@ spec:
           name: host-root-partition
         ports: 
         - containerPort: 161
+          protocol: UDP
+          hostPort: 161
         resources: {}
       volumes:
       - name: volume-snmpd-monitor


### PR DESCRIPTION
Close #2 
This PR fix issue #2  the requirement is to use the standard UDP port 161 to monitor the CVP VMs. 

The solution is to use a hostPort parameter in the deployment (as there is no constraint in the range of port used) instead of a Kubernetes service (`nodePort` must be between 9000-32000 by default). 

The Readme file has been updated accordingly.