### PR TITLE
Add ability to monitor physical interface traffic with SNMP

### DIFF
--- a/snmpd-monitor.yaml
+++ b/snmpd-monitor.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: snmpd-monitor
     spec:
+      hostNetwork: true
       containers:
       - image: net_snmp_image:latest
         imagePullPolicy: Never


### PR DESCRIPTION
Close #4 

The solution is to use the **hostNetwork** parameter inside the Kubernetes file to mount the host interface in the Kubernetes pod.