### PR TITLE
Update snmpd version and base alpine image version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ CMD ["/bootstrap.sh"]
 # Commands to build and save the image
 
 # 1. Building image
-# docker build --no-cache -t net_snmp_image:latest .
+# docker build --no-cache -t net_snmp_image:latest -t net_snmp_image:5.9.4 .
 
 # 2. Tests:
 # docker run --name docker-snmp -v $(pwd)/../snmpd.conf:/etc/snmp/snmpd.conf -it -d net_snmp_image:latest
@@ -27,5 +27,5 @@ CMD ["/bootstrap.sh"]
 # docker exec -it docker-snmp snmpwalk -v2c -c testing 127.0.0.1:161 1.3.6.1.2.1.25.1.1
 
 # 3. Saving image as a file
-# docker save net_snmp_image:latest -o net_snmp_image
+# docker save net_snmp_image -o net_snmp_image
 # tar -zcvf ../net_snmp_image-v5.9.tar.gz net_snmp_image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
-# Docker image based on alpine 3.18.2
+# Docker image based on alpine 3.19.0
 # This file is used in order to re-create the image in case we want to upgrade either the base image or the snmp package version.
 
-FROM alpine:3.18.2
+FROM alpine:3.19.0
 
 RUN apk --update --no-cache add net-snmp net-snmp-tools
 
@@ -18,5 +18,6 @@ CMD ["/bootstrap.sh"]
 # Commands to build and save the image
 
 # docker build -t net_snmp_image:latest .
+# docker run -it net_snmp_image:latest snmpd --version
 # docker save net_snmp_image:latest -o net_snmp_image
 # tar -zcvf ../net_snmp_image-v5.9.tar.gz net_snmp_image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,15 @@ CMD ["/bootstrap.sh"]
 
 # Commands to build and save the image
 
+# 1. Building image
 # docker build --no-cache -t net_snmp_image:latest .
-# docker run -it net_snmp_image:latest snmpd --version
+
+# 2. Tests:
+# docker run --name docker-snmp -v $(pwd)/../snmpd.conf:/etc/snmp/snmpd.conf -it -d net_snmp_image:latest
+# docker exec -it docker-snmp snmpd --version
+# docker exec -it docker-snmp snmpwalk -v2c -c testing 127.0.0.1:161 1.3.6.1.2.1.1.5.0
+# docker exec -it docker-snmp snmpwalk -v2c -c testing 127.0.0.1:161 1.3.6.1.2.1.25.1.1
+
+# 3. Saving image as a file
 # docker save net_snmp_image:latest -o net_snmp_image
 # tar -zcvf ../net_snmp_image-v5.9.tar.gz net_snmp_image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM alpine:3.19.0
 
-RUN apk --update --no-cache add net-snmp net-snmp-tools
+RUN apk --update --no-cache add net-snmp=5.9.4-r0 net-snmp-tools=5.9.4-r0
 
 COPY container-files /
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Docker image based on alpine 3.19.0
+# Docker image based on alpine.
 # This file is used in order to re-create the image in case we want to upgrade either the base image or the snmp package version.
 
 FROM alpine:3.19.0
@@ -17,7 +17,7 @@ CMD ["/bootstrap.sh"]
 
 # Commands to build and save the image
 
-# docker build -t net_snmp_image:latest .
+# docker build --no-cache -t net_snmp_image:latest .
 # docker run -it net_snmp_image:latest snmpd --version
 # docker save net_snmp_image:latest -o net_snmp_image
 # tar -zcvf ../net_snmp_image-v5.9.tar.gz net_snmp_image


### PR DESCRIPTION
Close #8 
Update: 
* based alpine version: 3.18.2 --> 3.19.0
* snmpd packages version: 5.9.3 --> 5.9.4

Docker comments have been updated and the docker image tag has also been added. 