### PR TITLE
[PROCESS]: Enable pod to see host process list for monitoring

### DIFF
--- a/snmpd-monitor.yaml
+++ b/snmpd-monitor.yaml
@@ -17,6 +17,8 @@ spec:
         app: snmpd-monitor
     spec:
       hostNetwork: true
+      # Enable the pod to access the host's /proc filesystem
+      hostPID: true
       containers:
       - image: net_snmp_image:latest
         imagePullPolicy: Never


### PR DESCRIPTION
Close #16
Enable the pod to view the full list of processes from the host. 
Example: 
/ # snmpwalk -v 2c -c testing localhost hrSWRunPerf | head
HOST-RESOURCES-MIB::hrSWRunPerfCPU.1 = INTEGER: 1323
HOST-RESOURCES-MIB::hrSWRunPerfCPU.2 = INTEGER: 2
HOST-RESOURCES-MIB::hrSWRunPerfCPU.3 = INTEGER: 0
HOST-RESOURCES-MIB::hrSWRunPerfCPU.4 = INTEGER: 0
HOST-RESOURCES-MIB::hrSWRunPerfCPU.5 = INTEGER: 0
HOST-RESOURCES-MIB::hrSWRunPerfCPU.6 = INTEGER: 0
HOST-RESOURCES-MIB::hrSWRunPerfCPU.8 = INTEGER: 0
HOST-RESOURCES-MIB::hrSWRunPerfCPU.10 = INTEGER: 0
HOST-RESOURCES-MIB::hrSWRunPerfCPU.11 = INTEGER: 0
HOST-RESOURCES-MIB::hrSWRunPerfCPU.12 = INTEGER: 0

That will allow the monitoring platform to track individual process utilization. 